### PR TITLE
Replace SMIRFF with SMIRNOFF throughout

### DIFF
--- a/openforcefield/data/README.md
+++ b/openforcefield/data/README.md
@@ -2,7 +2,6 @@
 
 ## Manifest
 - `atomtypes` - contains files used by smarty to determine how it samples over atom types
-- `forcefield` - contains sample SMIRFF ffxml files for different systems/regions of chemical space
+- `forcefield` - contains sample SMIRNOFF ffxml files for different systems/regions of chemical space
 - `molecules` - contains files for certain molecules used by smarty
-- `odds_files` - contains odds files used by smirky to influence sampling
 - `systems` - contains systems consisting of mixtures of molecules

--- a/openforcefield/data/forcefield/Frosst_AlkEtOH.ffxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEtOH.ffxml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<SMIRFF>
+<SMIRNOFF>
 
 <!-- SMIRKS (SMIRKS Force Field) mockup1.0 for alkanes, ethers, and alcohols -->
 <Date>Date: Tue May  3 2016</Date>
@@ -57,4 +57,4 @@
    <Atom smirks="[#8X2+0$(*-[#1]):1]" rmin_half="1.7210" epsilon="0.2104" id="n0011" parent_id="n0009"/> <!-- OH from frcmod.Frosst_AlkEthOH -->
 </NonbondedForce>
 
-</SMIRFF>
+</SMIRNOFF>

--- a/openforcefield/data/forcefield/Frosst_AlkEtOH_GBSA.ffxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEtOH_GBSA.ffxml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<SMIRFF>
+<SMIRNOFF>
 
 <!-- SMIRKS (SMIRKS Force Field) mockup1.0 for alkanes, ethers, and alcohols -->
 <Date>Date: Tue May  3 2016</Date>
@@ -73,4 +73,4 @@
   <Atom smirks="[#16:1]" radius="0.18" scale="0.96"/>
   <Atom smirks="[#17:1]" radius="0.17" scale="0.8"/>
 </GBSAForce>
-</SMIRFF>
+</SMIRNOFF>

--- a/openforcefield/data/forcefield/Frosst_AlkEtOH_MDL.ffxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEtOH_MDL.ffxml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<SMIRFF version="0.1" aromaticity_model="OEAroModel_MDL">
+<SMIRNOFF version="0.1" aromaticity_model="OEAroModel_MDL">
 
 <!-- SMIRKS (SMIRKS Force Field) mockup1.0 for alkanes, ethers, and alcohols -->
 <Date>Date: Tue May  3 2016</Date>
@@ -57,4 +57,4 @@
    <Atom smirks="[#8X2+0$(*-[#1]):1]" rmin_half="1.7210" epsilon="0.2104" id="n0011" parent_id="n0009"/> <!-- OH from frcmod.Frosst_AlkEthOH -->
 </NonbondedForce>
 
-</SMIRFF>
+</SMIRNOFF>

--- a/openforcefield/data/forcefield/Frosst_AlkEtOH_parmAtFrosst.ffxml
+++ b/openforcefield/data/forcefield/Frosst_AlkEtOH_parmAtFrosst.ffxml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<SMIRFF>
+<SMIRNOFF>
 
 <!-- SMIRFF (SMIRKS Force Field) mockup1.0 for alkanes, ethers, and alcohols -->
 <Date>Date: Tue May  3 2016</Date>
@@ -60,4 +60,4 @@
    <Atom smirks="[#8X2+0$(*-[#1]):1]" rmin_half="1.7210" epsilon="0.2104" id="n0011" parent_id="n0009"/> <!-- OH from frcmod.Frosst_AlkEthOH -->
 </NonbondedForce>
 
-</SMIRFF>
+</SMIRNOFF>

--- a/openforcefield/data/forcefield/benzene_minimal.ffxml
+++ b/openforcefield/data/forcefield/benzene_minimal.ffxml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<SMIRFF version="0.1" aromaticity_model="OEAroModel_MDL">
+<SMIRNOFF version="0.1" aromaticity_model="OEAroModel_MDL">
   <!-- SMIRKS FORCE FIELD (SMIRFF) FILE -->
   <Date>Date: Sept. 22, 2016</Date>
   <Author>D. L. Mobley, UC Irvine</Author>
@@ -23,4 +23,4 @@
     <Atom smirks="[#1:1]-[#6X3]" epsilon="0.0150" id="n8" rmin_half="1.4590"/>
     <Atom smirks="[#6:1]" epsilon="0.0860" id="n15" rmin_half="1.9080"/>
   </NonbondedForce>
-</SMIRFF>
+</SMIRNOFF>

--- a/openforcefield/data/forcefield/smirnoff99Frosst.ffxml
+++ b/openforcefield/data/forcefield/smirnoff99Frosst.ffxml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ASCII'?>
-<SMIRFF version="0.1" aromaticity_model="OEAroModel_MDL">
-  <!-- SMIRKS (SMIRKS Force Field) template file -->
+<SMIRNOFF version="0.1" aromaticity_model="OEAroModel_MDL">
+  <!-- SMIRNOFF (SMIRKS Native Open Force Field) template file -->
   <Date>Date: Mar. 3, 2017</Date>
   <Author>C. I. Bayly, OpenEye/UC Irvine; C. C. Bannan, UC Irvine; D. L. Mobley, UC Irvine</Author>
   <!-- This file is meant for processing via smarty.forcefield -->
@@ -304,4 +304,4 @@
     <Atom smirks="[#35:1]" epsilon="0.320" id="n26" rmin_half="2.22"/>
     <Atom smirks="[#53:1]" epsilon="0.40" id="n27" rmin_half="2.35"/>
   </NonbondedForce>
-</SMIRFF>
+</SMIRNOFF>

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -372,14 +372,14 @@ def test_create_system_boxes_features(verbose=False):
         for f in check_boxes(forcefield, description="to test Parm@frosst parameters with charge method %s" % str(chargeMethod), chargeMethod=chargeMethod, verbose=verbose):
             yield f
 
-def test_create_system_boxes_smirff99Frosst(verbose=False):
+def test_create_system_boxes_smirnoff99Frosst(verbose=False):
     """Test creation of a System object from some boxes of mixed solvents to test parm@frosst forcefield.
     """
-    forcefield = ForceField(get_data_filename('forcefield/smirff99Frosst.ffxml'))
+    forcefield = ForceField(get_data_filename('forcefield/smirnoff99Frosst.ffxml'))
     for f in check_boxes(forcefield, description="to test Parm@frosst parameters", verbose=verbose):
         yield f
 
-def test_smirff_energies_vs_parmatfrosst(verbose=False):
+def test_smirnoff_energies_vs_parmatfrosst(verbose=False):
     """Test evaluation of energies from parm@frosst ffxml files versus energies of equivalent systems."""
 
     from openeye import oechem

--- a/openforcefield/tests/test_smirnoff.py
+++ b/openforcefield/tests/test_smirnoff.py
@@ -112,34 +112,34 @@ ffxml_gbsa = u"""\
 ffxml_contents_gbsa = u"""\
 <?xml version="1.0"?>
 
-<SMIRFF use_fractional_bondorder="True">
+<SMIRNOFF use_fractional_bondorder="True">
 
 %(ffxml_standard)s
 %(ffxml_constraints)s
 %(ffxml_gbsa)s
 
-</SMIRFF>
+</SMIRNOFF>
 """ % globals()
 
 ffxml_contents_noconstraints = u"""\
 <?xml version="1.0"?>
 
-<SMIRFF use_fractional_bondorder="True">
+<SMIRNOFF use_fractional_bondorder="True">
 
 %(ffxml_standard)s
 
-</SMIRFF>
+</SMIRNOFF>
 """ % globals()
 
 ffxml_contents = u"""\
 <?xml version="1.0"?>
 
-<SMIRFF use_fractional_bondorder="True">
+<SMIRNOFF use_fractional_bondorder="True">
 
 %(ffxml_standard)s
 %(ffxml_constraints)s
 
-</SMIRFF>
+</SMIRNOFF>
 """ % globals()
 
 # Set up another, super minimal FF to test that alternate aromaticity
@@ -147,7 +147,7 @@ ffxml_contents = u"""\
 ffxml_MDL_contents = u"""\
 <?xml version="1.0"?>
 
-<SMIRFF version="0.1" aromaticity_model="OEAroModel_MDL">
+<SMIRNOFF version="0.1" aromaticity_model="OEAroModel_MDL">
 
 !-- SMIRKS (SMIRKS Force Field) minimal file, not intended for use -->
   <Date>Date: Sept. 7, 2016</Date>
@@ -167,7 +167,7 @@ ffxml_MDL_contents = u"""\
     <Atom smirks="[*:1]" epsilon="0.2100" id="n1" rmin_half="1.6612"/>
     <Atom smirks="[#1:1]" epsilon="0.0157" id="n2" rmin_half="0.6000"/>
   </NonbondedForce>
-</SMIRFF>
+</SMIRNOFF>
 """
 
 def positions_from_oemol(mol):
@@ -264,7 +264,7 @@ def check_system_creation_from_molecule(forcefield, mol, chargeMethod=None, verb
     Parameters
     ----------
     forcefield : ForceField
-        SMIRFF forcefield
+        SMIRNOFF forcefield
     mol : oechem.OEMol
         Molecule to test (need not have coordinates)
     chargeMethod : str, optional, default=None
@@ -280,12 +280,12 @@ def check_system_creation_from_molecule(forcefield, mol, chargeMethod=None, verb
 
 def check_system_creation_from_topology(forcefield, topology, mols, positions, chargeMethod=None, verbose=False):
     """
-    Generate a System from the given topology, OEMols matching the contents of the topology, and SMIRFF forcefield and check that its energy is finite.
+    Generate a System from the given topology, OEMols matching the contents of the topology, and SMIRNOFF forcefield and check that its energy is finite.
 
     Parameters
     ----------
     forcefield : ForceField
-        SMIRFF forcefield
+        SMIRNOFF forcefield
     topology : simtk.openmm.app.Topology
         Topology to construct system from
     mols : list of oechem.OEMol
@@ -531,7 +531,7 @@ def test_improper(verbose = False):
     # Check that torsional energies the same to 1 in 10^6
     rel_error = np.abs(( g0['torsion']-g1['torsion'])/ g0['torsion'])
     if rel_error > 2e-5: #Note that this will not be tiny because we use six-fold impropers and they use a single improper
-        raise Exception("Improper torsion energy for benzene differs too much (relative error %.4g) between AMBER and SMIRFF." % rel_error )
+        raise Exception("Improper torsion energy for benzene differs too much (relative error %.4g) between AMBER and SMIRNOFF." % rel_error )
 
 
 def test_MDL_aromaticity(verbose=False):
@@ -731,7 +731,7 @@ def test_component_combination():
             raise Exception('Error: Residue %s in cyclohexane-ethanol test system has a charge of zero, which is incorrect.' % resnr)
 
 def test_merge_system():
-    """Test merging of a system created from AMBER and another created from SMIRFF."""
+    """Test merging of a system created from AMBER and another created from SMIRNOFF."""
 
     #Create System from AMBER
     prefix = os.path.join('systems', 'amber', 'cyclohexane_ethanol_0.4_0.6')

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -521,12 +521,12 @@ class ForceField(object):
     """
 
     def __init__(self, *files):
-        """Load one or more XML parameter definition files and create a SMIRFF ForceField object based on them.
+        """Load one or more XML parameter definition files and create a SMIRNOFF ForceField object based on them.
 
         Parameters
         ----------
         files : list
-            A list of XML files defining the SMIRFF force field.
+            A list of XML files defining the SMIRNOFF force field.
             Each entry may be an absolute file path, a path relative to the current working directory, a path relative to this module's data subdirectory (for built in force fields), or an open file-like object with a read() method from which the forcefield XML data can be loaded.
 
         """
@@ -534,12 +534,12 @@ class ForceField(object):
         self.loadFile(files)
 
     def loadFile(self, files):
-        """Load a SMIRFF XML file and add the definitions from it to this ForceField.
+        """Load a SMIRNOFF XML file and add the definitions from it to this ForceField.
 
         Parameters
         ----------
         files : string or file or tuple
-            An XML file or tuple of XML files containing SMIRFF force field definitions.
+            An XML file or tuple of XML files containing SMIRNOFF force field definitions.
             Each entry may be an absolute file path, a path relative to the current working directory, a path relative to this module's data subdirectory (for built in force fields), or an open file-like object with a read() method from which the forcefield XML data can be loaded.
         """
 
@@ -589,7 +589,8 @@ class ForceField(object):
 
         # Store forcefield version info and, if present, aromaticity model
         root = trees[0].getroot()
-        if root.tag=='SMIRFF':
+        # Formerly known as SMIRFF, now SMIRNOFF
+        if root.tag=='SMIRFF' or root.tag=='SMIRNOFF':
             if 'version' in root.attrib:
                 #TO DO: Should this be a float, a string, or something else?
                 self.version = float(root.attrib['version'])
@@ -604,7 +605,7 @@ class ForceField(object):
             else:
                 self._use_fractional_bondorder = False
         else:
-            raise ValueError("Error: ForceField parses a SMIRFF forcefield, but this does not appear to be one as the root tag is %s." % root.tag)
+            raise ValueError("Error: ForceField parses a SMIRNOFF forcefield, but this does not appear to be one as the root tag is %s." % root.tag)
 
         # Load force definitions
         for tree in trees:
@@ -1278,7 +1279,7 @@ class ConstraintGenerator(object):
     """
 
     class ConstraintType(object):
-        """A SMIRFF constraint type."""
+        """A SMIRNOFF constraint type."""
         def __init__(self, node, parent):
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)
             self.pid = _extractQuantity(node, parent, 'id')
@@ -1294,7 +1295,7 @@ class ConstraintGenerator(object):
         self._constraint_types = list()
 
     def registerConstraint(self, node, parent):
-        """Register a SMIRFF constraint type definition."""
+        """Register a SMIRNOFF constraint type definition."""
         constraint = ConstraintGenerator.ConstraintType(node, parent)
         self._constraint_types.append(constraint)
 
@@ -1308,7 +1309,7 @@ class ConstraintGenerator(object):
         else:
             generator = existing[0]
 
-        # Register all SMIRFF constraint definitions.
+        # Register all SMIRNOFF constraint definitions.
         for constraint in element.findall('Constraint'):
             generator.registerConstraint(constraint, element)
 
@@ -1378,7 +1379,7 @@ class HarmonicBondGenerator(object):
     """A HarmonicBondGenerator constructs a HarmonicBondForce."""
 
     class BondType(object):
-        """A SMIRFF bond type."""
+        """A SMIRNOFF bond type."""
         def __init__(self, node, parent):
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)
             self.pid = _extractQuantity(node, parent, 'id')
@@ -1411,7 +1412,7 @@ class HarmonicBondGenerator(object):
         self._bondtypes = list()
 
     def registerBond(self, node, parent):
-        """Register a SMIRFF bondtype definition."""
+        """Register a SMIRNOFF bondtype definition."""
         bond = HarmonicBondGenerator.BondType(node, parent)
         self._bondtypes.append(bond)
 
@@ -1425,7 +1426,7 @@ class HarmonicBondGenerator(object):
         else:
             generator = existing[0]
 
-        # Register all SMIRFF bond definitions.
+        # Register all SMIRNOFF bond definitions.
         for bond in element.findall('Bond'):
             generator.registerBond(bond, element)
 
@@ -1541,7 +1542,7 @@ class HarmonicAngleGenerator(object):
     """A HarmonicAngleGenerator constructs a HarmonicAngleForce."""
 
     class AngleType(object):
-        """A SMIRFF angle type."""
+        """A SMIRNOFF angle type."""
         def __init__(self, node, parent):
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)
             self.angle = _extractQuantity(node, parent, 'angle')
@@ -1557,7 +1558,7 @@ class HarmonicAngleGenerator(object):
         self._angletypes = list()
 
     def registerAngle(self, node, parent):
-        """Register a SMIRFF angletype definition."""
+        """Register a SMIRNOFF angletype definition."""
         angle = HarmonicAngleGenerator.AngleType(node, parent)
         self._angletypes.append(angle)
 
@@ -1571,7 +1572,7 @@ class HarmonicAngleGenerator(object):
         else:
             generator = existing[0]
 
-        # Register all SMIRFF angle definitions.
+        # Register all SMIRNOFF angle definitions.
         for angle in element.findall('Angle'):
             generator.registerAngle(angle, element)
 
@@ -1663,7 +1664,7 @@ class PeriodicTorsionGenerator(object):
 
     class ProperTorsionType(object):
 
-        """A SMIRFF torsion type for proper torsions."""
+        """A SMIRNOFF torsion type for proper torsions."""
         def __init__(self, node, parent):
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)
             self.periodicity = list()
@@ -1706,7 +1707,7 @@ class PeriodicTorsionGenerator(object):
 
     class ImproperTorsionType(object):
 
-        """A SMIRFF torsion type for improper torsions."""
+        """A SMIRNOFF torsion type for improper torsions."""
         def __init__(self, node, parent):
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)
             self.periodicity = list()
@@ -1742,7 +1743,7 @@ class PeriodicTorsionGenerator(object):
                     idivf = _extractQuantity(node, parent, 'idivf%d' % index)
                     self.k[-1] /= float(idivf)
                 index += 1
-                # SMIRFF applies trefoil (six-fold) impropers unlike AMBER
+                # SMIRNOFF applies trefoil (six-fold) impropers unlike AMBER
                 # If it's an improper, divide by the factor of six internally
                 if node.tag=='Improper':
                     self.k[-1] /= 6.
@@ -1757,12 +1758,12 @@ class PeriodicTorsionGenerator(object):
         self._impropertorsiontypes = list()
 
     def registerProperTorsion(self, node, parent):
-        """Register a SMIRFF torsiontype definition for a proper."""
+        """Register a SMIRNOFF torsiontype definition for a proper."""
         torsion = PeriodicTorsionGenerator.ProperTorsionType(node, parent)
         self._propertorsiontypes.append(torsion)
 
     def registerImproperTorsion(self, node, parent):
-        """Register a SMIRFF torsiontype definition for an improper."""
+        """Register a SMIRNOFF torsiontype definition for an improper."""
         torsion = PeriodicTorsionGenerator.ImproperTorsionType(node, parent)
         self._impropertorsiontypes.append(torsion)
 
@@ -1776,7 +1777,7 @@ class PeriodicTorsionGenerator(object):
         else:
             generator = existing[0]
 
-        # Register all SMIRFF torsion definitions.
+        # Register all SMIRNOFF torsion definitions.
         for torsion in element.findall('Proper'):
             generator.registerProperTorsion(torsion, element)
         for torsion in element.findall('Improper'):
@@ -1911,7 +1912,7 @@ class NonbondedGenerator(object):
     SCALETOL = 1e-5
 
     class LennardJonesType(object):
-        """A SMIRFF Lennard-Jones type."""
+        """A SMIRNOFF Lennard-Jones type."""
         def __init__(self, node, parent):
             """Currently we support radius definition via 'sigma' or 'rmin_half'."""
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)
@@ -2084,7 +2085,7 @@ class BondChargeCorrectionGenerator(object):
     """A BondChargeCorrectionGenerator handles <BondChargeCorrections>."""
 
     class BondChargeCorrectionType(object):
-        """A SMIRFF bond type."""
+        """A SMIRNOFF bond type."""
         def __init__(self, node, parent):
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)
             self.increment = _extractQuantity(node, parent, 'increment')
@@ -2102,7 +2103,7 @@ class BondChargeCorrectionGenerator(object):
             raise Exception("BondChargeCorrectionGenerator: initialChargeMethod attribute was '%s', but '%s' was not found in oequacpac available methods." % (initialChargeMethod, self._oechargemethod))
 
     def registerBondChargeCorrection(self, node, parent):
-        """Register a SMIRFF bondtype definition."""
+        """Register a SMIRNOFF bondtype definition."""
         bond = BondChargeCorrectionGenerator.BondChargeCorrectionType(node, parent)
         self._bondChargeCorrections.append(bond)
 
@@ -2120,7 +2121,7 @@ class BondChargeCorrectionGenerator(object):
 
             generator = existing[0]
 
-        # Register all SMIRFF bond definitions.
+        # Register all SMIRNOFF bond definitions.
         for bond in element.findall('BondChargeCorrection'):
             generator.registerBondChargeCorrection(bond, element)
 
@@ -2214,7 +2215,7 @@ class GBSAForceGenerator(object):
     }
 
     class GBSAType(object):
-        """A SMIRFF GBSA type."""
+        """A SMIRNOFF GBSA type."""
         def __init__(self, node, parent):
             """Create a GBSAType"""
             self.smirks = _validateSMIRKS(node.attrib['smirks'], node=node)

--- a/openforcefield/typing/engines/smirnoff/forcefield_utils.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield_utils.py
@@ -76,12 +76,12 @@ def create_system_from_amber( prmtop_filename, crd_filename, verbose = False ):
 
 def create_system_from_molecule(forcefield, mol, verbose=False):
     """
-    Generate a System from the given OEMol and SMIRFF forcefield, return the resulting System.
+    Generate a System from the given OEMol and SMIRNOFF forcefield, return the resulting System.
 
     Parameters
     ----------
     forcefield : ForceField
-        SMIRFF forcefield
+        SMIRNOFF forcefield
     mol : oechem.OEMol
         Molecule to test (must have coordinates)
 
@@ -110,7 +110,7 @@ def create_system_from_molecule(forcefield, mol, verbose=False):
 
     return topology, system, positions
 
-def compare_system_energies( topology0, topology1, system0, system1, positions0, positions1=None, label0="AMBER system", label1 = "SMIRFF system", verbose = True, skip_assert = False, skip_improper = False ):
+def compare_system_energies( topology0, topology1, system0, system1, positions0, positions1=None, label0="AMBER system", label1 = "SMIRNOFF system", verbose = True, skip_assert = False, skip_improper = False ):
     """
     Given two OpenMM systems, check that their energies and component-wise
     energies are consistent, and return these. The same positions will be used
@@ -125,7 +125,7 @@ def compare_system_energies( topology0, topology1, system0, system1, positions0,
     system0 : OpenMM System
         First system for comparison (usually from AMBER)
     system1 : OpenMM System
-        Second system for comparison (usually from SMIRFF)
+        Second system for comparison (usually from SMIRNOFF)
     positions0 : simtk.unit.Quantity wrapped
         Positions to use for energy evaluation comparison
     positions1 (optional) : simtk.unit.Quantity wrapped (optional)
@@ -134,7 +134,7 @@ def compare_system_energies( topology0, topology1, system0, system1, positions0,
     label0 (optional) : str
         String labeling system0 for output. Default, "AMBER system"
     label1 (optional) : str
-        String labeling system1 for output. Default, "SMIRFF system"
+        String labeling system1 for output. Default, "SMIRNOFF system"
     verbose (optional) : bool
         Print out info on energies, True/False (default True)
     skip_assert (optional) : bool
@@ -224,7 +224,7 @@ def compare_system_energies( topology0, topology1, system0, system1, positions0,
 def compare_molecule_energies( prmtop, crd, forcefield, mol, verbose = True, skip_assert=False, skip_improper = False):
     """
     Compare energies for OpenMM Systems/topologies created from an AMBER prmtop
-    and crd versus from a SMIRFF forcefield file and OEMol which should
+    and crd versus from a SMIRNOFF forcefield file and OEMol which should
     parameterize the same system with same parameters.
 
 
@@ -235,7 +235,7 @@ def compare_molecule_energies( prmtop, crd, forcefield, mol, verbose = True, ski
     crd_filename : str (filename)
         Filename of input AMBER format crd file
     forcefield : ForceField
-        SMIRFF forcefield
+        SMIRNOFF forcefield
     mol : oechem.OEMol
         Molecule to test
     verbose (optional): Bool
@@ -272,7 +272,7 @@ def compare_molecule_energies( prmtop, crd, forcefield, mol, verbose = True, ski
 
 
 def get_molecule_parameterIDs( oemols, ffxml):
-    """Process a list of oemols with a specified SMIRFF ffxml file and determine which parameters are used by which molecules, returning collated results.
+    """Process a list of oemols with a specified SMIRNOFF ffxml file and determine which parameters are used by which molecules, returning collated results.
 
 
     Parameters
@@ -335,14 +335,14 @@ def get_molecule_parameterIDs( oemols, ffxml):
     return parameters_by_molecule, parameters_by_ID
 
 def getMolParamIDToAtomIndex( oemol, ff):
-    """Take an OEMol and a SMIRFF forcefield object and return a dictionary, keyed by parameter ID, where each entry is a tuple of ( smirks, [[atom1, ... atomN], [atom1, ... atomN]) giving the SMIRKS corresponding to that parameter ID and a list of the atom groups in that molecule that parameter is applied to.
+    """Take an OEMol and a SMIRNOFF forcefield object and return a dictionary, keyed by parameter ID, where each entry is a tuple of ( smirks, [[atom1, ... atomN], [atom1, ... atomN]) giving the SMIRKS corresponding to that parameter ID and a list of the atom groups in that molecule that parameter is applied to.
 
     Parameters
     ----------
     oemol : OEMol
         OpenEye OEMol with the molecule to investigate.
     ff : ForceField
-        SMIRFF ForceField object (obtained from an ffxml via ForceField(ffxml)) containing FF of interest.
+        SMIRNOFF ForceField object (obtained from an ffxml via ForceField(ffxml)) containing FF of interest.
 
     Returns
     -------
@@ -363,7 +363,7 @@ def getMolParamIDToAtomIndex( oemol, ff):
 
     return param_usage
 
-def merge_system( topology0, topology1, system0, system1, positions0, positions1, label0="AMBER system", label1 = "SMIRFF system", verbose = True):
+def merge_system( topology0, topology1, system0, system1, positions0, positions1, label0="AMBER system", label1 = "SMIRNOFF system", verbose = True):
     """Merge two given OpenMM systems. Returns the merged OpenMM System.
 
     Parameters
@@ -375,7 +375,7 @@ def merge_system( topology0, topology1, system0, system1, positions0, positions1
     system0 : OpenMM System
         First system for merging (usually from AMBER)
     system1 : OpenMM System
-        Second system for merging (usually from SMIRFF)
+        Second system for merging (usually from SMIRNOFF)
     positions0 : simtk.unit.Quantity wrapped
         Positions to use for energy evaluation comparison
     positions1 (optional) : simtk.unit.Quantity wrapped (optional)
@@ -383,7 +383,7 @@ def merge_system( topology0, topology1, system0, system1, positions0, positions1
     label0 (optional) : str
         String labeling system0 for output. Default, "AMBER system"
     label1 (optional) : str
-        String labeling system1 for output. Default, "SMIRFF system"
+        String labeling system1 for output. Default, "SMIRNOFF system"
     verbose (optional) : bool
         Print out info on topologies, True/False (default True)
 


### PR DESCRIPTION
This attempts to clean up everywhere SMIRFF (the old name) appears in the repo and replace it with SMIRNOFF, except in one place within the `ForceField` class where I (at least temporarily) retained the ability for this to also process `ffxml` files with `SMIRFF` tags rather than `SMIRNOFF` tags.
