### PR TITLE
Fixing loadFile for forcefield with files in data directory

### DIFF
--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -33,7 +33,7 @@ import lxml.etree as etree
 
 from simtk.openmm.app import element as elem
 from simtk.openmm.app import Topology
-from openforcefield.utils import generateTopologyFromOEMol
+from openforcefield.utils import generateTopologyFromOEMol, get_data_filename
 
 import os
 import math
@@ -555,7 +555,9 @@ class ForceField(object):
                 # this handles either filenames or open file-like objects
                 tree = etree.parse(file, parser)
             except IOError:
-                tree = etree.parse(os.path.join(os.path.dirname(__file__), 'data', file), parser)
+                temp_file = get_data_filename(file)
+                tree = etree.parse(temp_file, parser)
+                #tree = etree.parse(os.path.join(os.path.dirname(__file__), 'data', file), parser)
             except Exception as e:
                 # Fail with an error message about which file could not be read.
                 # TODO: Also handle case where fallback to 'data' directory encounters problems,

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -557,7 +557,6 @@ class ForceField(object):
             except IOError:
                 temp_file = get_data_filename(file)
                 tree = etree.parse(temp_file, parser)
-                #tree = etree.parse(os.path.join(os.path.dirname(__file__), 'data', file), parser)
             except Exception as e:
                 # Fail with an error message about which file could not be read.
                 # TODO: Also handle case where fallback to 'data' directory encounters problems,


### PR DESCRIPTION
I'm addressing the issue #22. I'm taking advantage of the method get_data_filename from utils to get access to the data directory. 

The previous version seemed to look for a data directory at 
openforcefield/typing/engines/smirnoff/data/
instead of just
openforcefield/data/