### PR TITLE
Add tip3p SMIRNOFF parameters and fix scrambled VdW parameters in mixtures

### DIFF
--- a/openforcefield/data/forcefield/tip3p.ffxml
+++ b/openforcefield/data/forcefield/tip3p.ffxml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='ASCII'?>
+<SMIRNOFF version="0.1">
+  <!-- SMIRks Native Open Force Field (SMIRNOFF) file -->
+  <Date>2017-04-29</Date>
+  <Author>J. D. Chodera, MSKCC; A. Rizzi, Weill Cornell; C. C. Bannan, UC Irvine</Author>
+  <!-- SMIRNOFF file implementing TIP3P water model. -->
+  <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="nanometers" epsilon_unit="kilojoules_per_mole">
+    <!-- TIP3P water oxygen with charge override -->
+    <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968" charge="-0.834"/>
+    <!-- TIP3P water hydrogen with charge override -->
+    <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" id="n2" sigma="1" epsilon="0" charge="0.417"/>
+  </NonbondedForce>
+  <Constraints distance_unit="angstroms">
+    <!-- constrain water O-H bond to equilibrium bond length (overrides earlier constraint) -->
+    <Constraint smirks="[#1:1]-[#8X2H2+0:2]-[#1]" id="c1" distance="0.9572"/>
+    <!-- constrain water H...H, calculating equilibrium length from H-O-H equilibrium angle and H-O equilibrium bond lengths -->
+    <Constraint smirks="[#1:1]-[#8X2H2+0]-[#1:2]" id="c2" distance="1.5139006545247014"/>
+  </Constraints>
+</SMIRNOFF>

--- a/openforcefield/data/forcefield/tip3p.ffxml
+++ b/openforcefield/data/forcefield/tip3p.ffxml
@@ -6,8 +6,10 @@
   <!-- SMIRNOFF file implementing TIP3P water model. -->
   <NonbondedForce coulomb14scale="0.833333" lj14scale="0.5" sigma_unit="nanometers" epsilon_unit="kilojoules_per_mole">
     <!-- TIP3P water oxygen with charge override -->
+    <!-- WARNING: charges are not supported yet (see issue openforcefield#25), and they are currently here only for documentation -->
     <Atom smirks="[#1]-[#8X2H2+0:1]-[#1]" id="n1" sigma="0.31507524065751241" epsilon="0.635968" charge="-0.834"/>
     <!-- TIP3P water hydrogen with charge override -->
+    <!-- WARNING: charges are not supported yet (see issue openforcefield#25), and they are currently here only for documentation -->
     <Atom smirks="[#1:1]-[#8X2H2+0]-[#1]" id="n2" sigma="1" epsilon="0" charge="0.417"/>
   </NonbondedForce>
   <Constraints distance_unit="angstroms">

--- a/openforcefield/data/systems/monomers/tip3p_water.mol2
+++ b/openforcefield/data/systems/monomers/tip3p_water.mol2
@@ -1,0 +1,14 @@
+@<TRIPOS>MOLECULE
+HOH
+3 2 1 0 0
+SMALL
+USER_CHARGES
+@<TRIPOS>ATOM
+       1 O           4.1330    4.6480    8.4360 O.t3p     1 HOH     -0.834000
+       2 H1          3.7930    5.1250    9.1930 H.t3p     1 HOH      0.417000
+       3 H2          3.3710    4.1940    8.0770 H.t3p     1 HOH      0.417000
+@<TRIPOS>BOND
+       1    1    2 1
+       2    1    3 1
+@<TRIPOS>SUBSTRUCTURE
+       1 HOH         1 TEMP              0 ****  ****    0 ROOT

--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -2020,7 +2020,7 @@ class NonbondedGenerator(object):
             for atom_mapping in atom_mappings:
                 for (atom_index, map_atom_index) in atom_mapping.items():
                     # Retrieve NB params for reference atom (charge not set yet)
-                    [charge, sigma, epsilon] = force.getParticleParameters(atom_index)
+                    charge, sigma, epsilon = force.getParticleParameters(map_atom_index)
                     # Look up the charge on the atom in the reference molecule
                     charge = charge_by_atom[atom_index]*unit.elementary_charge
 


### PR DESCRIPTION
Fix #24: Add `tip3p.ffxml` to `data/forcefield/`.
Fix #30: Sigma and epsilon parameters scrambled in mixtures.

- I've interpreted the `Date` and `Author` tags related to the creation of the file, but if these were intended to describe date and author of the parameters, I'll change it.
- @jchodera: I've changed the H-H constrained distance w.r.t. to what you proposed in #24 from 1.8532A to 1.5139006545247014A as those are the one that ends up being used in OpenMM. I've also changed the charges to the TIP3P ones: should I leave them there even if they're not currently supported, or do we want to add the `charge` attributes back when #25 will be implemented?
- I've added `data/monomers/tip3p_water.mol2` because `data/monomers/water.mol2` didn't have tip3p charges or a residue name recognized by OpenMM. I'm using it for tests, and I'll use this file to set up SMIRNOFF hydration free energy calculations.
- Note that the test I've added (`test_smirnoff.py: test_tip3p_solvated_molecule_energy`) [adds unnecessary bonds](https://github.com/open-forcefield-group/openforcefield/blob/tip3p-and-fix-30/openforcefield/tests/test_smirnoff.py#L675-L685) as a workaround for ParmEd/ParmEd#868 . Those bonds will have to be removed if/when that's fixed.