### PR TITLE
Add icu dependency, add conda-forge dependency, drop python3.4, support python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == false ]; then echo "OpenEye license will not be installed in forks."; fi
 
 script:
-  # Add omnia channel
+  # Add omnia and conda-forge channel
   - conda config --add channels ${ORGNAME}
+  - conda config --add channels conda-forge
   # Create and activate test environment
   - conda create --yes -n test python=$python
   - source activate test

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ script:
 env:
   matrix:
     - python=2.7  CONDA_PY=27
-    - python=3.4  CONDA_PY=34
     - python=3.5  CONDA_PY=35
+    - python=3.6  CONDA_PY=36
 
   global:
     - ORGNAME="omnia"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install -i https://pypi.anaconda.org/OpenEye/simple OpenEye-toolkits
 ```
 Install `openforcefield` tools via conda:
 ```bash
-conda install --yes -c omnia openforcefield
+conda install --yes -c conda-forge -c omnia openforcefield
 ```
 
 # Tools

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - numpy
     - networkx
     - lxml
-    - icu ==58.*  # This is a lxml dependency but sometimes conda installs version 56
+    - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
     - openmoltools >=0.7.3
     - parmed
     - matplotlib

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - python
     - setuptools
     - pandas
+    - icu ==58.*  # This is a lxml dependency but sometimes conda installs version 56
 
   run:
     - python

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - numpy
     - networkx
     - lxml
-    - icu =58.*  # This is a lxml dependency but sometimes conda installs version 56
+    - icu ==58.*  # This is a lxml dependency but sometimes conda installs version 56
     - openmoltools >=0.7.3
     - parmed
     - matplotlib

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,7 +14,6 @@ requirements:
     - python
     - setuptools
     - pandas
-    - icu ==58.*  # This is a lxml dependency but sometimes conda installs version 56
 
   run:
     - python

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - numpy
     - networkx
     - lxml
+    - icu =58.*  # This is a lxml dependency but sometimes conda installs version 56
     - openmoltools >=0.7.3
     - parmed
     - matplotlib


### PR DESCRIPTION
This fixes the repo conda recipe to add explicitly the `icu` library as a dependency. I'll soon update the one in `conda-recipes` too.