### PR TITLE
Fix "missing atom names" bug and issue with constraint labeling

### DIFF
--- a/openforcefield/typing/engines/smirnoff/forcefield.py
+++ b/openforcefield/typing/engines/smirnoff/forcefield.py
@@ -1355,7 +1355,7 @@ class ConstraintGenerator(object):
         # Iterate over all defined constraint SMIRKS, allowing later matches to override earlier ones.
         constraints = ValenceDict()
         for constraint in self._constraint_types:
-            for atom_indices in topology.unrollSMIRKSMatches(constraint.smirks, aromaticity_model = self.ff._aromaticity_model):
+            for atom_indices in getSMIRKSMatches_OEMol(oemol, constraint.smirks, aromaticity_model = self.ff._aromaticity_model):
                 constraints[atom_indices] = constraint
 
         if verbose:
@@ -1363,7 +1363,7 @@ class ConstraintGenerator(object):
             print('ConstraintGenerator:')
             print('')
             for constraint in self._constraint_types:
-                print('%64s : %8d matches' % (constraint.smirks, len(topology.unrollSMIRKSMatches(constraint.smirks, aromaticity_model = self.ff._aromaticity_model))))
+                print('%64s : %8d matches' % (constraint.smirks, len(getSMIRKSMatches_OEMol(oemol, constraint.smirks, aromaticity_model = self.ff._aromaticity_model))))
             print('')
 
         # Add all bonds to the output list

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -191,12 +191,15 @@ def generateTopologyFromOEMol(molecule):
     for atom in mol.GetAtoms():
         name = atom.GetName()
         element = elem.Element.getByAtomicNumber(atom.GetAtomicNum())
-        atom = topology.addAtom(name, element, residue)
+        openmm_atom = topology.addAtom(name, element, residue)
 
     # Create bonds.
     atoms = { atom.name : atom for atom in topology.atoms() }
     for bond in mol.GetBonds():
-        topology.addBond(atoms[bond.GetBgn().GetName()], atoms[bond.GetEnd().GetName()])
+        aromatic = None
+        if bond.IsAromatic(): aromatic = 'Aromatic'
+        # Add bond, preserving order assessed by OEChem
+        topology.addBond(atoms[bond.GetBgn().GetName()], atoms[bond.GetEnd().GetName()], type=aromatic, order=bond.GetOrder())
 
     return topology
 

--- a/openforcefield/utils/utils.py
+++ b/openforcefield/utils/utils.py
@@ -183,7 +183,7 @@ def generateTopologyFromOEMol(molecule):
     if any([atom.GetName() =='' for atom in mol.GetAtoms()]):
         oechem.OETriposAtomNames(mol)
     # Check names are unique; non-unique names will also cause a problem
-    atomnames = [ atom.GetName() for atom in mol.GetAtoms())
+    atomnames = [ atom.GetName() for atom in mol.GetAtoms() ]
     if any( atomnames.count(atom.GetName())>1 for atom in mol.GetAtoms()):
         raise Exception("Error: Reference molecule must have unique atom names in order to create a Topology.")
 


### PR DESCRIPTION
This pull request:
- Fixes a bug where OEMols without atom names couldn't be used to generate an OpenMM `Topology` via the utility functionality of `generateTopologyFromOEMol` because the atom names were used to create bonds, etc. (https://github.com/open-forcefield-group/openforcefield/issues/47)
- Fixes constraint force labeling (https://github.com/open-forcefield-group/openforcefield/issues/42)
- Makes `generateTopologyFromOEMol` generate OpenMM topologies which attempt to retain bond order (though nothing is done with this yet), to allow for eventual round-tripping of OEMol-> OpenMM Topology -> OEMol.