### PR TITLE
Pin networkx to 1.11 to avoid code-breaking API changes for 2.0

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - numpy
-    - networkx
+    - networkx ==1.11
     - lxml
     - icu 58*  # This is a lxml dependency but sometimes conda installs version 56
     - openmoltools >=0.7.3


### PR DESCRIPTION
Addresses #63 in devtools.