### PR TITLE
Doc improvements: Fix typo in README.md; add format document link to mixedFF

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For example, if we have an `OEMol` named `mol`, we can create an OpenMM `System`
 ```python
 # Import the SMIRNOFF forcefield engine and some useful tools
 from openforcefield.typing.engines.smirnoff import ForceField
-from openforcefield.utils import read_molecules, get_data_filename, generateTopologyFromOEMol 
+from openforcefield.utils import read_molecules, get_data_filename, generateTopologyFromOEMol
 
 # read in molecule from file in openforcefield/data/molecules/
 mols = read_molecules('benzene.mol2')
@@ -67,17 +67,17 @@ forcefield = ForceField(FF_filename)
 system = forcefield.createSystem(topology, mols)
 ```
 See `examples/SMIRNOFF_simulation/` for a complete example of how SMIRNOFF can be used for small molecule vacuum simulations, and `examples/mixedFF_structure` for how to set up a system which uses an AMBER forcefield (in this case, AMBER99SB-ILDN) for a protein in combination with SMIRNOFF for a small molecules. Via ParmEd, this can be translated into GROMACS, AMBER, or CHARMM formats for use elsewhere (and additional formats via InterMol).
-**For an especially complete worked example, see complete setup of a host-guest simulation in water with SMIRNOFF**, including docking, 2D and 3D visualization, etc., in `examples/host_guest_simulation/smirnoff_host_guest.ipynb`` (Jupyter notebook).
+**For an especially complete worked example, see complete setup of a host-guest simulation in water with SMIRNOFF**, including docking, 2D and 3D visualization, etc., in `examples/host_guest_simulation/smirnoff_host_guest.ipynb` (Jupyter notebook).
 
 ## `ChemicalEnvironment`: Tools for chemical environment perception and manipulation
 
-ChemicalEnvironments are a python class used to parse and manipulate SMIRKS strings. 
-They were created with the goal of being able to automatically sample over chemical perceptions space. 
-Someday they will be used to generate SMIRKS patterns for SMIRKS Native-Open Force Fields parameters. 
-These are initiated with SMIRKS strings for single molecules fragements`*` and then the information is stored for each atom and bond in the initial fragment. 
+ChemicalEnvironments are a python class used to parse and manipulate SMIRKS strings.
+They were created with the goal of being able to automatically sample over chemical perceptions space.
+Someday they will be used to generate SMIRKS patterns for SMIRKS Native-Open Force Fields parameters.
+These are initiated with SMIRKS strings for single molecules fragements`*` and then the information is stored for each atom and bond in the initial fragment.
 
 `*` NOTE SMIRKS can be used to show how a reaction would happen between fragments in different molecules. This is done with `'.'` between molecules and `'>>'` to indicate a reaction. Chemical Environments can only parse SMIRKS strings for fragments of a single molecule.  
- 
+
 ```python
 from openforcefield.typing.chemistry import environment
 
@@ -96,12 +96,12 @@ print(alpha.asSMIRKS()) # smirks for atom only
 print(angle.asSMIRKS())
 # "[#6X3,#7:1]~;@[#8;r:2]~;@[#6X3,#7:3]~;!@[#8X2]"
 ```
-If you are not familiar with the SMIRKS language, take a look at these Daylight resources: 
+If you are not familiar with the SMIRKS language, take a look at these Daylight resources:
 * [SMILES](http://www.daylight.com/dayhtml_tutorials/languages/smiles/index.html)
 * [SMARTS](http://www.daylight.com/dayhtml/doc/theory/theory.smarts.html)
 * [SMIRKS](http://www.daylight.com/dayhtml_tutorials/languages/smirks/index.html)
 
-For more detailed examples see README and `using_environment.ipynb` in  `examples/chemicalEnvironments/` 
+For more detailed examples see README and `using_environment.ipynb` in  `examples/chemicalEnvironments/`
 
 # Manifest
 

--- a/The-SMIRNOFF-force-field-format.md
+++ b/The-SMIRNOFF-force-field-format.md
@@ -315,6 +315,9 @@ So, for example, one can read a PDB file describing a mixture and provide OpenEy
 
 One important note is that the OpenEye molecules currently must have atom names, hence the [`OETriposAtomNames`](https://docs.eyesopen.com/toolkits/python/oechemtk/OEChemFunctions/OETriposAtomNames.html) above.
 
+**Use with protein force fields**: While SMIRNOFF format force fields can cover a wide range of biological systems, an initial focus is on small molecule force fields, meaning that users may have considerable interest in combining SMIRNOFF small molecule parameters to systems in combination with traditional biopolymer parameters from conventional force fields, such as the AMBER family of protein/nucleic acid force fields.
+Thus, we provide an example of setting up a mixed system in [`examples/mixedFF_structure`](examples/mixedFF_structure), where an AMBER family force field is used for a protein and smirnoff99Frosst for a small molecule.
+
 ### `id` and other XML attributes
 
 In general, other XML attributes can be specified and will be ignored by `ForceField` unless they are specifically handled by the parser (and specified in this document).


### PR DESCRIPTION
Fixes a typo in the README.md and adds a link in the format document to example showing how to mix force fields.